### PR TITLE
Set green icon on reset when running.

### DIFF
--- a/src/win_main.cc
+++ b/src/win_main.cc
@@ -457,7 +457,10 @@ void WinMain::on_button_restart_clicked()
   time_elapsed = atoi(configs.work_interval.c_str())*60;
   
   lblCycle->set_markup(generate_cycle());
-	lblDisplay->set_text(generate_display());
+  lblDisplay->set_text(generate_display());
+  if (started) {
+      set_green_icon();
+  }
 }
 
 void WinMain::on_button_finish_clicked()


### PR DESCRIPTION
When the timer is running the icon is not properly set on `Reset`. I.e. when timer is reset during the rest phase icon stays red instead of green.
